### PR TITLE
Adding cluster setting for search ignore unavailable

### DIFF
--- a/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/opensearch/action/search/TransportSearchAction.java
@@ -1080,6 +1080,10 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             // No user preference defined in search request - apply cluster service default
             searchRequest.allowPartialSearchResults(searchService.defaultAllowPartialSearchResults());
         }
+        if (searchRequest.ignoreUnavailable() == null) {
+            // No user preference defined in search request - apply cluster service default
+            searchRequest.ignoreUnavailable(searchService.defaultIgnoreUnavailable());
+        }
         if (searchRequest.isSuggestOnly()) {
             // disable request cache if we have only suggest
             searchRequest.requestCache(false);

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -390,6 +390,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
                 ClusterManagerService.CLUSTER_MANAGER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
                 SearchService.DEFAULT_SEARCH_TIMEOUT_SETTING,
                 SearchService.DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS,
+                SearchService.DEFAULT_IGNORE_UNAVAILABLE,
                 TransportSearchAction.SHARD_COUNT_LIMIT_SETTING,
                 TransportSearchAction.SEARCH_CANCEL_AFTER_TIME_INTERVAL_SETTING,
                 TransportSearchAction.SEARCH_QUERY_METRICS_ENABLED_SETTING,

--- a/server/src/main/java/org/opensearch/search/SearchService.java
+++ b/server/src/main/java/org/opensearch/search/SearchService.java
@@ -230,6 +230,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         Property.NodeScope
     );
 
+    // Keeping the default value to maintain existing behaviour
+    public static final Setting<Boolean> DEFAULT_IGNORE_UNAVAILABLE = Setting.boolSetting(
+        "search.default_ignore_unavailable",
+        false,
+        Property.Dynamic,
+        Property.NodeScope
+    );
+
     public static final Setting<Integer> MAX_OPEN_SCROLL_CONTEXT = Setting.intSetting(
         "search.max_open_scroll_context",
         500,
@@ -312,6 +320,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     private volatile boolean defaultAllowPartialSearchResults;
 
+    private volatile boolean defaultIgnoreUnavailable;
+
     private volatile boolean lowLevelCancellation;
 
     private volatile int maxOpenScrollContext;
@@ -380,6 +390,10 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         defaultAllowPartialSearchResults = DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS.get(settings);
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(DEFAULT_ALLOW_PARTIAL_SEARCH_RESULTS, this::setDefaultAllowPartialSearchResults);
+
+        defaultIgnoreUnavailable = DEFAULT_IGNORE_UNAVAILABLE.get(settings);
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(DEFAULT_IGNORE_UNAVAILABLE, this::setDefaultIgnoreUnavailable);
 
         maxOpenScrollContext = MAX_OPEN_SCROLL_CONTEXT.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_OPEN_SCROLL_CONTEXT, this::setMaxOpenScrollContext);
@@ -451,6 +465,14 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     public boolean defaultAllowPartialSearchResults() {
         return defaultAllowPartialSearchResults;
+    }
+
+    private void setDefaultIgnoreUnavailable(boolean defaultIgnoreUnavailable) {
+        this.defaultIgnoreUnavailable = defaultIgnoreUnavailable;
+    }
+
+    public boolean defaultIgnoreUnavailable() {
+        return defaultIgnoreUnavailable;
     }
 
     private void setMaxOpenScrollContext(int maxOpenScrollContext) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Adds cluster level setting for ignoring unavailable shards during search request execution

### Related Issues
Resolves #12371

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Failing checks are inspected and point to the corresponding known issue(s) (See: [Troubleshooting Failing Builds](../blob/main/CONTRIBUTING.md#troubleshooting-failing-builds))
- [ ] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
